### PR TITLE
Fix: add x86_64-linux platform for Render

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -158,8 +158,11 @@ GEM
     nio4r (2.7.5)
     nokogiri (1.18.10-aarch64-linux-gnu)
       racc (~> 1.4)
+    nokogiri (1.18.10-x86_64-linux-gnu)
+      racc (~> 1.4)
     orm_adapter (0.5.0)
     pg (1.6.2-aarch64-linux)
+    pg (1.6.2-x86_64-linux)
     pp (0.6.3)
       prettyprint
     prettyprint (0.2.0)
@@ -270,6 +273,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   bootsnap


### PR DESCRIPTION
Renderデプロイのため、Gemfile.lockに
```
PLATFORMS
  aarch64-linux
  x86_64-linux
```
を追加