### PR TITLE
change:ログイン後のヘッダーのアイコンからの遷移先が、食品一覧ページになるように修正

### DIFF
--- a/app/views/devise/shared/_header.html.erb
+++ b/app/views/devise/shared/_header.html.erb
@@ -2,7 +2,7 @@
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 w-full">
     <div class="flex justify-between items-center h-27">
       <div class="flex-shrink-0 flex items-center">
-        <%= link_to root_path, class: "group flex items-center hover:opacity-70 transition-opacity" do %>
+        <%= link_to foods_path, class: "group flex items-center hover:opacity-70 transition-opacity" do %>
           <%= image_tag 'Fridge_Note_Logo.png', alt: "FridgeNoteロゴ", class: "w-20 h-25" %>
           <h1 class="text-xl md:text-3xl font-bold tracking-wide">
             Fridge <br>Note


### PR DESCRIPTION
## 概要
<!-- PR の目的を簡潔に -->
ログイン後のヘッダーのアイコンからの遷移先が、食品一覧ページになるように修正しました。
→従前はトップページへの遷移でした。

## 変更内容
<!-- 主な変更点を箇条書きで -->
- root_path → foods_path

## 目的・背景
<!-- なぜこの変更が必要だったか -->
今後、買い物リストやその他ページが追加された際、ワンクリックで食材一覧へ戻れるようにするため

## 参考サイト
https://zenn.dev/yuna0960740/articles/dbea6e1ad45b01
