### PR TITLE
update:エラーメッセージのUIを見やすく変更

### DIFF
--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,12 +1,12 @@
 <% if resource.errors.any? %>
-  <div id="error_explanation" data-turbo-cache="false">
+  <div id="error_explanation" data-turbo-cache="false" class="bg-error text-on-error px-5 py-4 rounded-xl border border-on-error/20 mb-6 shadow-sm">
     <h2>
       <%= I18n.t("errors.messages.not_saved",
                  count: resource.errors.count,
                  resource: resource.class.model_name.human.downcase)
        %>
     </h2>
-    <ul>
+    <ul class="list-disc list-inside ml-2 text-sm font-medium space-y-1 opacity-90">
       <% resource.errors.full_messages.each do |message| %>
         <li><%= message %></li>
       <% end %>

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -17,6 +17,8 @@ ja:
               too_long: "は%{count}文字以下に設定して下さい。"
               invalid: "は有効でありません。"
               confirmation: "が内容とあっていません。"
+            current_password:
+              invalid: "は不正な値です。"
     attributes:
       user:
         current_password: "現在のパスワード"


### PR DESCRIPTION
## 概要
<!-- PR の目的を簡潔に -->
エラーメッセージのUIを見やすく変更

## 変更内容
<!-- 主な変更点を箇条書きで -->
- エラーメッセージを黒字→赤字にする
- メッセージに句点がある場合とない場合があったため、手動で修正

## 目的・背景
<!-- なぜこの変更が必要だったか -->
- エラーメッセージが黒字だと、エラーが起こっているのか一目でわからなかったため。

## 動作確認項目
- [ ] エラーメッセージがきちんと赤字で表示される
