### PR TITLE
add:draperを導入し、FoodDecoratorを作成

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,8 @@ gem "stimulus-rails"
 # Build JSON APIs with ease [https://github.com/rails/jbuilder]
 gem "jbuilder"
 
+gem 'draper'
+
 gem 'rails-i18n'
 
 gem "devise"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,6 +52,10 @@ GEM
       globalid (>= 0.3.6)
     activemodel (8.1.1)
       activesupport (= 8.1.1)
+    activemodel-serializers-xml (1.0.3)
+      activemodel (>= 5.0.0.a)
+      activesupport (>= 5.0.0.a)
+      builder (~> 3.1)
     activerecord (8.1.1)
       activemodel (= 8.1.1)
       activesupport (= 8.1.1)
@@ -111,6 +115,13 @@ GEM
     devise-i18n (1.15.0)
       devise (>= 4.9.0)
       rails-i18n
+    draper (4.0.6)
+      actionpack (>= 5.0)
+      activemodel (>= 5.0)
+      activemodel-serializers-xml (>= 1.0)
+      activesupport (>= 5.0)
+      request_store (>= 1.0)
+      ruby2_keywords
     drb (2.2.3)
     erb (6.0.0)
     erubi (1.13.1)
@@ -222,10 +233,13 @@ GEM
     regexp_parser (2.11.3)
     reline (0.6.3)
       io-console (~> 0.5)
+    request_store (1.7.0)
+      rack (>= 1.4)
     responders (3.2.0)
       actionpack (>= 7.0)
       railties (>= 7.0)
     rexml (3.4.4)
+    ruby2_keywords (0.0.5)
     rubyzip (3.2.1)
     securerandom (0.4.1)
     selenium-webdriver (4.38.0)
@@ -282,6 +296,7 @@ DEPENDENCIES
   debug
   devise
   devise-i18n
+  draper
   importmap-rails
   jbuilder
   pg (~> 1.5)

--- a/app/decorators/food_decorator.rb
+++ b/app/decorators/food_decorator.rb
@@ -1,0 +1,13 @@
+class FoodDecorator < Draper::Decorator
+  delegate_all
+
+  # Define presentation-specific methods here. Helpers are accessed through
+  # `helpers` (aka `h`). You can override attributes, for example:
+  #
+  #   def created_at
+  #     helpers.content_tag :span, class: 'time' do
+  #       object.created_at.strftime("%a %m/%d/%y")
+  #     end
+  #   end
+
+end

--- a/test/decorators/food_decorator_test.rb
+++ b/test/decorators/food_decorator_test.rb
@@ -1,0 +1,4 @@
+require 'test_helper'
+
+class FoodDecoratorTest < Draper::TestCase
+end


### PR DESCRIPTION
## 概要
<!-- PR の目的を簡潔に -->
デコレーター（Draper）を導入しました。
今後の食品一覧画面実装において、賞味期限による色分けなどの表示ロジックをViewから分離するための土台作りです。

## 変更内容
<!-- 主な変更点を箇条書きで -->
- Gemfile に draper を追加し、インストール
- rails g decorator Food コマンドにより FoodDecorator を作成

## 目的・背景
<!-- なぜこの変更が必要だったか -->
食品一覧画面にて「賞味期限切れなら赤色」「3日以内なら黄色」といった条件分岐が発生する予定です。その色分けロジックにつき、decoratorに切り分ける予定です。

## 参考サイト
<!-- あれば記載 -->
[Draper GitHub](https://github.com/drapergem/draper)