### PR TITLE
セキュリティ強化のために認証ガードを共通化

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::Base
+  before_action :authenticate_user!
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   protected

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,4 +1,6 @@
 class StaticPagesController < ApplicationController
+  skip_before_action :authenticate_user!
+
   def terms
   end
 

--- a/app/controllers/top_controller.rb
+++ b/app/controllers/top_controller.rb
@@ -1,3 +1,5 @@
 class TopController < ApplicationController
+  skip_before_action :authenticate_user!
+
   layout "top"
 end


### PR DESCRIPTION
## 概要
<!-- PR の目的を簡潔に -->
セキュリティ強化とコードの保守性向上のため、ログイン認証（`authenticate_user!`）を `ApplicationController` に移動し、アプリ全体でデフォルト必須としました。

## 変更内容
<!-- 主な変更点を箇条書きで -->
### 認証ロジックの共通化
* **ApplicationController**
    * `before_action :authenticate_user!` を追加。
    * これにより、意図しない未認証アクセスを防止します。
* **TopController / StaticPagesController**
    * 誰でも閲覧可能なページ（トップ、規約、プライバシー等）には `skip_before_action` を設定し、例外的にアクセスを許可しました。

## 目的・背景
<!-- なぜこの変更が必要だったか -->
セキュリティ強化のためです。

## 動作確認項目
- [ ] トップページや利用規約は未ログインでも閲覧できること。

## 参考サイト
<!-- あれば記載 -->
[deviseのよく使うメソッド集](https://qiita.com/3062_in_zamud/items/3a9e9cd61419253c2e65)