### PR TITLE
fix:賞味期限をdate型に変更し、入力フォームをdate_fieldに修正

### DIFF
--- a/app/views/foods/_form.html.erb
+++ b/app/views/foods/_form.html.erb
@@ -10,7 +10,7 @@
   </div>
   <div class="mb-4">
     <%= f.label :expiry_date %>
-    <%= f.datetime_field :expiry_date %>
+    <%= f.date_field :expiry_date %>
   </div>
   <div class="mb-4">
     <%= f.label :quantity %>

--- a/db/migrate/20251217133043_change_expiry_date_to_date.rb
+++ b/db/migrate/20251217133043_change_expiry_date_to_date.rb
@@ -1,0 +1,5 @@
+class ChangeExpiryDateToDate < ActiveRecord::Migration[8.1]
+  def change
+    change_column :foods, :expiry_date, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2025_12_13_093634) do
+ActiveRecord::Schema[8.1].define(version: 2025_12_17_133043) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -25,7 +25,7 @@ ActiveRecord::Schema[8.1].define(version: 2025_12_13_093634) do
   create_table "foods", force: :cascade do |t|
     t.bigint "category_id"
     t.datetime "created_at", null: false
-    t.datetime "expiry_date"
+    t.date "expiry_date"
     t.string "memo"
     t.string "name"
     t.integer "quantity"


### PR DESCRIPTION
## 概要
<!-- PR の目的を簡潔に -->
食品の賞味期限について、時刻情報が不要だったため、日付単位で扱うように修正しました。

## 変更内容
<!-- 主な変更点を箇条書きで -->
- foods テーブルの `expiry_date` を `date` 型に変更
- 食品登録・編集フォームの入力を `date_field` に統一

## 目的・背景
<!-- なぜこの変更が必要だったか -->
賞味期限は日付情報のみで十分なため、`datetime` 型および時刻入力は不要と判断しました。
