### PR TITLE
fix:食材を数量のみでも登録できるように修正

### DIFF
--- a/app/decorators/food_decorator.rb
+++ b/app/decorators/food_decorator.rb
@@ -5,11 +5,6 @@ class FoodDecorator < Draper::Decorator
     object.category&.name || "未分類"
   end
 
-  def quantity_with_unit
-    return nil if object.quantity.blank? || object.unit.blank?
-    "#{object.quantity} #{object.unit}"
-  end
-
   def display_expiry_date
     object.expiry_date&.strftime("%Y.%m.%d")
   end

--- a/app/views/foods/_food.html.erb
+++ b/app/views/foods/_food.html.erb
@@ -16,7 +16,7 @@
     </div>
 
     <%# 中段：数量と単位（大きめに設定）／gap %>
-    <% if food.decorate.quantity_with_unit %>
+    <% if food.quantity.present? %>
       <div class="flex items-baseline gap-1 text-[#2C5159] mb-3">
         <span class="text-xs text-gray-400 font-bold">残り</span>
         <span class="font-montserrat text-3xl font-bold tracking-tight">


### PR DESCRIPTION
## 概要
<!-- PR の目的を簡潔に -->
数量と数詞を一緒に入力しなければ登録できなかったため、柔軟に、数量のみでも登録できるよう修正しました。

## 変更内容
<!-- 主な変更点を箇条書きで -->
- 'food_decorator.rb'から、数量とunitに共に値がある場合のみ登録できるようにするロジックを消去
- '_food.html.erb'で'quantity'のみ入力の有無を確認し、入力していない時に「残り」等文字が残らないように軌道修正。

## 目的・背景
<!-- なぜこの変更が必要だったか -->
細かい数量には拘らないが、数量のみ登録したいニーズに応える必要があると考えました。

## 動作確認項目
- [ ] 数量を入力した場合、数詞がなくても登録できること
