### PR TITLE
fix: Renderデプロイ用にdatabase.ymlを修正(Solid Queue対応)

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -16,7 +16,6 @@ default: &default
   adapter: postgresql
   encoding: unicode
   pool: 5
-  host: db
   username: postgres
   password: password
   port: 5432
@@ -25,6 +24,7 @@ default: &default
 
 development:
   <<: *default
+  host: db
   database: chilltrack_development
 
   # The specified database role being used to connect to PostgreSQL.
@@ -59,6 +59,7 @@ development:
 # Do not set this db to the same as development or production.
 test:
   <<: *default
+  host: db
   database: chilltrack_test
 
 # As with config/credentials.yml, you never want to store sensitive information,
@@ -84,10 +85,7 @@ test:
 production:
   primary: &primary_production
     <<: *default
-    database: app_production
-    username: app
-    password: <%= ENV["APP_DATABASE_PASSWORD"] %>
+    url: <%= ENV["DATABASE_URL"] %>
   queue:
     <<: *primary_production
-    database: app_production_queue
     migrations_paths: db/queue_migrate


### PR DESCRIPTION
## 概要
<!-- PR の目的を簡潔に -->
Renderへのデプロイ時に発生していたデータベース接続エラー（PG::ConnectionBad）を修正し、Solid QueueがRender上で正しく動作するようにdatabase.ymlの構成を変更しました。

## 変更内容
<!-- 主な変更点を箇条書きで -->
Renderの仕様（DBは1つのみ）に合わせ、queue も primary と同じ DATABASE_URL を参照するように設定。

## 目的・背景
<!-- なぜこの変更が必要だったか -->
Renderへのデプロイエラーを解消するため。
RenderのDBは複数組み合わせられないため、postgreSQLと組み合わせて一つのDBにした。

## 参考サイト
<!-- あれば記載 -->
- [Solid Queue README -- DBベースのActive Jobバックエンド（翻訳）](https://techracho.bpsinc.jp/hachi8833/2025_09_29/140501)
- [Deploy a Rails 8 App on Render](https://render.com/docs/deploy-rails-8#create-your-render-services)