### PR TITLE
fix:Renderでマイグレーションを行うためにrender-buildを修正

### DIFF
--- a/bin/render-build
+++ b/bin/render-build
@@ -3,6 +3,7 @@
 set -o errexit
 
 bundle install
-bundle exec rake assets:precompile
-bundle exec rake assets:clean
-bundle exec rake db:migrate
+bundle exec rails assets:precompile
+bundle exec rails assets:clean
+
+bundle exec rails db:migrate


### PR DESCRIPTION
## 概要
<!-- PR の目的を簡潔に -->
Render デプロイ時に Solid Queue の recurring task 関連テーブルが存在せずエラーとなる問題を修正しました。

## 変更内容
<!-- 主な変更点を箇条書きで -->
- render-build スクリプトに `rails db:migrate` を追加
  - Solid Queue のマイグレーションを含め、本番環境で必要なテーブルが確実に作成されるように対応

## 目的・背景
<!-- なぜこの変更が必要だったか -->
Render へのデプロイ時に以下のエラーが発生していました。
ERROR: relation "solid_queue_recurring_tasks" does not exist

これは Solid Queue の recurring task 用テーブルが本番環境でマイグレーションされていなかったことが原因です。
デプロイ時に自動でマイグレーションが適用されるよう、build スクリプトを修正しました。

## 参考サイト
<!-- あれば記載 -->
- [ビルドスクリプトを作成する](https://render.com/docs/deploy-rails-8#create-your-render-services)
- [rails/solid_queue](https://github.com/rails/solid_queue)