### PR TITLE
Renderデプロイ時にSolid Queueのテーブルを自動作成するよう修正

### DIFF
--- a/bin/render-build
+++ b/bin/render-build
@@ -2,31 +2,9 @@
 # exit on error
 set -o errexit
 
-# Gemのインストール
 bundle install
-
-# Solid Queueのテーブルがあるか確認して、なければ作る
-echo "Checking for Solid Queue tables..."
-SOLID_QUEUE_EXISTS=$(bundle exec rails runner "
-begin
- tables = ActiveRecord::Base.connection.tables.grep(/solid_queue/)
- puts tables.size >= 5 ? 'true' : 'false'
-rescue
- puts 'false'
-end
-")
-
-if [ "$SOLID_QUEUE_EXISTS" = "false" ]; then
-  echo "Solid Queue tables not found. Loading queue schema..."
-  # 既存データは消さずに、Solid Queueのテーブルだけをロードする
-  DISABLE_DATABASE_ENVIRONMENT_CHECK=1 bundle exec rails db:schema:load SCHEMA=db/queue_schema.rb
-else
-  echo "Solid Queue tables found."
-fi
-
-# 通常のマイグレーション（未実行分があれば実行）
-bundle exec rails db:migrate
-
-# アセット（CSS/JS）のビルド
 bundle exec rails assets:precompile
 bundle exec rails assets:clean
+bundle exec rails db:migrate
+
+bundle exec rails db:prepare:queue


### PR DESCRIPTION
## 概要
<!-- PR の目的を簡潔に -->
Render環境において、Solid Queue のテーブルが存在せずアプリ起動時にエラーになる問題を修正しました。

## 変更内容
<!-- 主な変更点を箇条書きで -->
- 

## 目的・背景
<!-- なぜこの変更が必要だったか -->
- 本番DBに `solid_queue_recurring_tasks` 等のテーブルが存在せず、起動時にエラーが発生していた
- Render無料プランでは Shell / one-off 実行が使えないため、build 時に `db:prepare:queue` を実行する構成とした

## 参考サイト
<!-- あれば記載 -->
