### PR TITLE
fix:デプロイエラーログに合わせて、puma.rbを修正

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -43,4 +43,4 @@ pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
 # Allow puma to be restarted by `bin/rails restart` command.
 plugin :tmp_restart
 
-plugin :solid_queue if Rails.env.development? || Rails.env.production?
+plugin :solid_queue if ENV["SOLID_QUEUE_IN_PUMA"] || rails_env == "development" || rails_env == "production"


### PR DESCRIPTION
## 概要
<!-- PR の目的を簡潔に -->
Render（本番環境）へのデプロイ時に発生していた Solid Queue 関連のエラー（PG::UndefinedTable および Puma の NameError）を修正しました。

## 変更内容
<!-- 主な変更点を箇条書きで -->
puma.rb:
- 本番環境でも Solid Queue が起動するようにプラグイン設定を追加
- 起動時の NameError を防ぐため、Rails.env ではなく rails_env 変数を使用するように修正

## 目的・背景
<!-- なぜこの変更が必要だったか -->
Renderの無料プランではデータベースを1つしか作成できませんが、アプリの設定が Solid Queue 用のDBを別に探す「マルチDB構成」になっていたため、solid_queue_recurring_tasks テーブルが見つからずエラーが発生していました。

また、puma.rb 内で Rails.env を使用していましたが、Puma起動時点では Rails がまだロードされていないため、デプロイ時にアプリがクラッシュする問題を修正する必要がありました。

## 参考サイト
<!-- あれば記載 -->
[Solid Queue README - Single database configuration](https://github.com/rails/solid_queue?tab=readme-ov-file#single-database-configuration)