### PR TITLE
fix: Renderでのメモリ不足対策としてPumaのスレッド数を削減

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -7,7 +7,7 @@
 # Any libraries that use thread pools should be configured to match
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum; this matches the default thread size of Active Record.
-max_threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }
+max_threads_count = ENV.fetch("RAILS_MAX_THREADS") { 3 }
 min_threads_count = ENV.fetch("RAILS_MIN_THREADS") { max_threads_count }
 threads min_threads_count, max_threads_count
 


### PR DESCRIPTION
## 概要
<!-- PR の目的を簡潔に -->
Renderで頻発している Ran out of memory（メモリ不足）エラーへの対策です。 Webサーバー（Puma）の設定を見直し、メモリ消費量を抑える設定に変更しました。

## 変更内容
<!-- 主な変更点を箇条書きで -->
config/puma.rb:
- スレッド数のデフォルト値を 5 から 3 に削減しました。
- ENV.fetch("RAILS_MAX_THREADS") { 3 }

## 目的・背景
<!-- なぜこの変更が必要だったか -->
現在、Renderの無料プランで、RailsアプリとSolid Queueを同居させています。 これまでのデフォルト設定（5スレッド）ではメモリ使用量が上限を超えてしまい、頻繁にインスタンスが強制終了していました。 同時処理数を減らすことで、1プロセスあたりのメモリ消費を抑え、安定稼働させることを目的としています
