### PR TITLE
【UI改善】ヘッダーのレスポンシブ対応とハンバーガーメニューの実装

### DIFF
--- a/app/javascript/controllers/hamburger_controller.js
+++ b/app/javascript/controllers/hamburger_controller.js
@@ -2,6 +2,10 @@ import { Controller } from "@hotwired/stimulus"
 
 // Connects to data-controller="hamburger"
 export default class extends Controller {
-  connect() {
+  static targets = [ "menu" ]
+
+  // ハンバーガーボタンを押した時に実行されるアクション
+  toggle() {
+    this.menuTarget.classList.toggle("hidden")
   }
 }

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -9,8 +9,8 @@
           </h1>
         <% end %>
       </div>
-
-      <div class="font-mplus flex items-center gap-4 text-base">
+      <%# ナビゲーションメニュー（デスクトップ表示） %>
+      <div class="hidden md:font-mplus md:flex items-center gap-4 text-base">
         <%= link_to notifications_path, data: { turbo_frame: :modal }, class: "text-[#2C5159]/80 hover:text-[#6BAFB9] transition-colors p-1" do %>
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-7">
             <path stroke-linecap="round" stroke-linejoin="round" d="M14.857 17.082a23.848 23.848 0 0 0 5.454-1.31A8.967 8.967 0 0 1 18 9.75V9A6 6 0 0 0 6 9v.75a8.967 8.967 0 0 1-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 0 1-5.714 0m5.714 0a3 3 0 1 1-5.714 0M3.124 7.5A8.969 8.969 0 0 1 5.292 3m13.416 0a8.969 8.969 0 0 1 2.168 4.5" />
@@ -20,6 +20,26 @@
         <%= link_to "買い物リスト", "#", class: "block font-bold hover:text-[#6BAFB9] transition-colors" %>
         <%= link_to "マイページ", user_path(current_user), class: "block font-bold hover:text-[#6BAFB9] transition-colors" %>
         <%= link_to "ログアウト", destroy_user_session_path, data: { turbo_method: :delete }, class: "font-bold border-2 border-[#2C5159] text-[#2C5159] px-4 py-2 rounded-full hover:bg-[#2C5159] hover:text-white transition-all" %>
+      </div>
+
+      <%# ハンバーガーメニュー（モバイル表示） %>
+      <div data-controller="hamburger" class="md:hidden flex flex-row items-center gap-4">
+        <%= link_to notifications_path, data: { turbo_frame: :modal }, class: "text-[#2C5159]/80 hover:text-[#6BAFB9] transition-colors p-1" do %>
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-7">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M14.857 17.082a23.848 23.848 0 0 0 5.454-1.31A8.967 8.967 0 0 1 18 9.75V9A6 6 0 0 0 6 9v.75a8.967 8.967 0 0 1-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 0 1-5.714 0m5.714 0a3 3 0 1 1-5.714 0M3.124 7.5A8.969 8.969 0 0 1 5.292 3m13.416 0a8.969 8.969 0 0 1 2.168 4.5" />
+          </svg>
+        <% end %>
+        <div data-action="click->hamburger#toggle">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5M12 17.25h8.25" />
+            </svg>
+          <div data-hamburger-target="menu" class="hidden font-mplus flex flex-col items-center gap-4 text-xs absolute top-20 right-4 bg-[#D6EFED]/95 backdrop-blur-sm border-2 border-[#6BAFB9]/90 shadow-md rounded-lg p-6 w-40">
+            <%= link_to "食材一覧", foods_path, class: "block font-bold hover:text-[#6BAFB9] transition-colors" %>
+            <%= link_to "買い物リスト", "#", class: "block font-bold hover:text-[#6BAFB9] transition-colors" %>
+            <%= link_to "マイページ", user_path(current_user), class: "block font-bold hover:text-[#6BAFB9] transition-colors" %>
+            <%= link_to "ログアウト", destroy_user_session_path, data: { turbo_method: :delete }, class: "font-bold border-2 border-[#2C5159] text-[#2C5159] px-4 py-2 rounded-full hover:bg-[#2C5159] hover:text-white transition-all" %>
+          </div>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## 概要
<!-- PR の目的を簡潔に -->
ヘッダーをレスポンシブ対応させました。 PC画面ではメニューを横並びにし、モバイルではハンバーガーメニューを表示するように切り替えています。

## 変更内容
<!-- 主な変更点を箇条書きで -->
ヘッダーのレスポンシブ化
- Tailwind CSSの md: を使用し、画面幅に応じてレイアウトが切り替わるようにしました。
- 通知アイコンは重要度が高いため、ハンバーガーメニュー内には隠さず、スマホ画面でも常に外に出しています。

ハンバーガーメニューの開閉機能
- Stimulusを使用して実装しました。
- ボタンクリック時にhiddenクラスを付け外しするようにしました。

## スクリーンショット
<!-- Before / After を貼るとレビューが早い -->
Before

[![Image from Gyazo](https://i.gyazo.com/e8f2e81c52ad75a4adf0990cb4d1f17e.png)](https://gyazo.com/e8f2e81c52ad75a4adf0990cb4d1f17e)

After

[![Image from Gyazo](https://i.gyazo.com/a0ff234abf8f7d94e185592ad420ba99.png)](https://gyazo.com/a0ff234abf8f7d94e185592ad420ba99)

## 目的・背景
<!-- なぜこの変更が必要だったか -->
冷蔵庫管理アプリは、スマホでの利用がメインだと想定されるため、レスポンシブ対応する必要があると考えました（tailwindはモバイルメインのcssでもあるため、追加しておりました）。

## 動作確認項目
- [ ] ヘッダーボタンが反応すること。

## 参考サイト
<!-- あれば記載 -->
- [ゼロから始めるstimulus入門1(ファーストコンタクト)](https://qiita.com/shinry/items/de697c4a679e14a41ffa)
- [Tailwind CSSで5分で作るレスポンシブデザイン完全ガイド](https://zenn.dev/unikoukokun/articles/3d86a99f72227c)