### PR TITLE
fix: バーコードスキャンのカメラ映像表示を改善

### DIFF
--- a/app/javascript/controllers/barcode_scanner_controller.js
+++ b/app/javascript/controllers/barcode_scanner_controller.js
@@ -34,9 +34,10 @@ export default class extends Controller {
           type: "LiveStream",
           target: this.cameraTarget,
           constraints: {
-            width:  { min: 640 },
-            height: { min: 480 },
-            facingMode: "environment", // 背面カメラ
+            width:  { ideal: 1280 },
+            height: { ideal: 720 },
+            aspectRatio: { ideal: 1.0 },  // 正方形に近づける
+            facingMode: "environment",
           },
         },
         locator: { patchSize: "medium", halfSample: true },

--- a/app/views/foods/_form.html.erb
+++ b/app/views/foods/_form.html.erb
@@ -14,8 +14,8 @@
 
         <%# カメラ映像エリア（スキャン中のみ表示） %>
         <div data-barcode-scanner-target="camera"
-          style="display: none;"
-          class="w-full rounded-lg overflow-hidden bg-black mb-2">
+            style="display: none;"
+            class="w-full rounded-lg overflow-hidden bg-black mb-2 max-h-64 [&_video]:w-full [&_video]:h-full [&_video]:object-cover [&_canvas]:hidden">
         </div>
 
         <%= f.text_field :name,


### PR DESCRIPTION
## 概要
バーコードスキャン時のカメラ映像エリアの表示崩れを修正しました。

## 問題
- カメラ映像が横長に表示されていた
- 映像エリアの下部に何も映らない真っ黒な余白が表示されていた

## 原因
Quagga2が内部で生成するvideo・canvas要素に対してサイズ指定がなく、
カメラの実解像度と表示エリアのサイズが一致していなかった。

## 対応
カメラエリアのdivにTailwindのネストセレクタでスタイルを適用。

- `max-h-64` で表示エリアの高さを256pxに制限
- `[&_video]:object-cover` で映像をエリアに合わせてトリミング
- `[&_canvas]:hidden` でQuagga2のデバッグ用canvasを非表示に